### PR TITLE
Prevent horizontal scrolling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10,7 +10,7 @@ html, body {
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 18px;
   -webkit-font-smoothing: antialiased;
-  overflow: auto;
+  overflow-x: hidden;
 
   /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#58afde+0,2c65cc+100 */
   background: #58afde; /* Old browsers */


### PR DESCRIPTION
Fixes issue where you can scroll horizontally when image is to right of text, this doesn't affect mobile as the image is displayed in full underneath!