### PR TITLE
Improve the quote marks on the home page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -285,7 +285,8 @@ h1, h2, h3, h4, h5, h6 {
   margin-top: 10%;
   text-align: center;
 }
-.quote-mark {
+.quote::before {
+  content: "“";
   font-family: 'Catamaran', -apple-system, BlinkMacSystemFont, 
     '.SFNSText-Regular', 'Helvetica Neue', Helvetica, sans-serif;
   font-size: 10rem;
@@ -293,6 +294,7 @@ h1, h2, h3, h4, h5, h6 {
   margin-top: 30px;
   margin-bottom: -20px;
   color: #a3aab1;
+  display: block;
 }
 .quote {
   margin-top: 2rem;

--- a/index.html
+++ b/index.html
@@ -200,7 +200,6 @@
 
     <div class="row">
       <div class="one-half column quote">
-        <div class="quote-mark">"</div>
         <p>It’s great to see a solid, native iOS Git client being built in the open. <a href="https://twitter.com/githawk?ref_src=twsrc%5Etfw">@githawk</a> is really nice to use, too! <a href="https://t.co/BDzssAHlWn">https://t.co/BDzssAHlWn</a></p>
         <div class="author">
           <a href="https://twitter.com/tonyarnold/status/982741440726876160?ref_src=twsrc%5Etfw">
@@ -210,7 +209,6 @@
         </div>
       </div>
       <div class="one-half column quote">
-        <div class="quote-mark">"</div>
         <p>You should try out <a href="https://twitter.com/githawk?ref_src=twsrc%5Etfw">@githawk</a> for a nice way to handle GitHub notifications and pull requests on iOS.</p>
         <div class="author">
           <a href="https://twitter.com/WorkingCopyApp/status/986996557047369728?ref_src=twsrc%5Etfw">
@@ -223,7 +221,6 @@
 
     <div class="row">
       <div class="one-half column quote">
-        <div class="quote-mark">"</div>
         <p>Just tried <a href="https://twitter.com/_ryannystrom?ref_src=twsrc%5Etfw">@_ryannystrom</a> ‘s githawk on iPad and folks - IT IS EVEN BETTER !</p>
         <div class="author">
           <a href="https://twitter.com/icanzilb/status/1001466964613713921?ref_src=twsrc%5Etfw">
@@ -233,7 +230,6 @@
         </div>
       </div>
       <div class="one-half column quote">
-        <div class="quote-mark">"</div>
         <p>I&#39;ve been using <a href="https://twitter.com/githawk?ref_src=twsrc%5Etfw">@githawk</a> for almost a year now. I just had an extraordinary pleasant experience with it with respect to handling 6 different PRs. I just wanted to tell <a href="https://twitter.com/_ryannystrom?ref_src=twsrc%5Etfw">@_ryannystrom</a> &amp; <a href="https://twitter.com/BasThomas?ref_src=twsrc%5Etfw">@BasThomas</a> kudos and wanted to spread the word a bit. This app is a MUS HAVE dev tool!</p>
         <div class="author">
           <a href="https://twitter.com/ArtSabintsev/status/1007091186388094977?ref_src=twsrc%5Etfw">


### PR DESCRIPTION
- Insert them using `::before` so they’re consistent & not selectable
- Fix the direction — the originals were closing quotes.